### PR TITLE
Add `CompilationUnitSyntax.EndOfFileToken` after 'the code'

### DIFF
--- a/src/DotnetCombine/Model/SourceFile.cs
+++ b/src/DotnetCombine/Model/SourceFile.cs
@@ -17,6 +17,8 @@ internal class SourceFile
 
     public IEnumerable<string> Code => _root.Members.Select(m => m.ToFullString());
 
+    public string EndOfFile => _root.EndOfFileToken.ToFullString();
+
     public string? Namespace => _root.DescendantNodes().OfType<BaseNamespaceDeclarationSyntax>()?.FirstOrDefault()?.Name.ToString();
 
     public SourceFile(string filePath)

--- a/src/DotnetCombine/Services/Combiner.cs
+++ b/src/DotnetCombine/Services/Combiner.cs
@@ -173,6 +173,7 @@ public class Combiner
 
             codeSection.Append(Environment.NewLine);
             codeSection.AppendJoin(Environment.NewLine, parsedFile.Code);
+            codeSection.AppendJoin(Environment.NewLine, parsedFile.EndOfFile);
             codeSection.Append(Environment.NewLine);
         }
 

--- a/tests/DotnetCombine.Test/CombinerTests/PreprocessorAtEoFTests.cs
+++ b/tests/DotnetCombine.Test/CombinerTests/PreprocessorAtEoFTests.cs
@@ -1,0 +1,51 @@
+﻿using DotnetCombine.Options;
+using DotnetCombine.Services;
+using Xunit;
+
+namespace DotnetCombine.Test.CombinerTests;
+
+public class PreprocessorAtEoFTests : BaseCombinerTests
+{
+    [Fact]
+    public async Task Endif()
+    {
+        // Arrange
+        var initialCsFile = Path.Combine(DefaultOutputDir, $"{nameof(Endif)}-input" + Combiner.OutputExtension);
+        var outputCsFile = Path.Combine(DefaultOutputDir, $"{nameof(Endif)}-output" + Combiner.OutputExtension);
+
+        const string originalContent = @"
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Running;
+using System.Reflection;
+
+//Lynx.Benchmark.BitBoard_Struct_ReadonlyStruct_Class_Record.SizeTest();
+
+#if DEBUG
+BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly()).Run(args, new DebugInProcessConfig());
+#else
+            BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly()).Run(args);
+#endif
+";
+
+        CreateFile(initialCsFile, originalContent);
+
+        // Act
+        var options = new CombineOptions()
+        {
+            Output = outputCsFile,
+            OverWrite = true,
+            Input = initialCsFile
+        };
+
+        var exitCode = await new Combiner(options).Run();
+
+        // Assert
+        Assert.Equal(0, exitCode);
+
+        var oldContent = (await File.ReadAllLinesAsync(initialCsFile));
+        var newContent = (await File.ReadAllLinesAsync(outputCsFile)).Where(l => l.Length > 0);
+
+        Assert.Equal(oldContent.Last(), newContent.Last());
+        Assert.Contains("#endif", newContent.Last());
+    }
+}


### PR DESCRIPTION
Make sure to append `CompilationUnitSyntax.EndOfFileToken` after the `CompilationUnitSyntax.Members` (aka 'the code')
This fixes https://github.com/eduherminio/dotnet-combine/issues/95