### PR TITLE
Fix namespace annotation

### DIFF
--- a/src/DotnetCombine/SyntaxRewriters/AnnotateNamespacesRewriter.cs
+++ b/src/DotnetCombine/SyntaxRewriters/AnnotateNamespacesRewriter.cs
@@ -31,11 +31,11 @@ internal class AnnotateNamespacesRewriter : BaseCustomRewriter
             var existingTriviaString = existingTrivia?.ToString();
 
             return SyntaxFactory.Comment(
-                $"// {_message}" +
-                $"{(existingTriviaString?.StartsWith(Environment.NewLine) == true   // i.e. false when there's an #if directive at the beinning of the file
-                    ? ""
-                    : Environment.NewLine)}");
-        }
+            $"// {_message}" +
+            $"{(existingTriviaString?.StartsWith(Environment.NewLine) == true   // i.e. false when there's an #if directive at the beinning of the file
+                ? ""
+                : Environment.NewLine)}");
+    }
 
         if (node.HasLeadingTrivia)
         {

--- a/src/DotnetCombine/SyntaxRewriters/AnnotateNamespacesRewriter.cs
+++ b/src/DotnetCombine/SyntaxRewriters/AnnotateNamespacesRewriter.cs
@@ -26,8 +26,16 @@ internal class AnnotateNamespacesRewriter : BaseCustomRewriter
     private T AddComment<T>(T node)
         where T : BaseNamespaceDeclarationSyntax
     {
-        SyntaxTrivia TriviaToAdd(SyntaxTriviaList? existingTrivia = null) => SyntaxFactory.Comment($"// {_message}" +
-            $"{(existingTrivia?.ToString().EndsWith("\n") == true ? "" : Environment.NewLine)}");
+        SyntaxTrivia TriviaToAdd(SyntaxTriviaList? existingTrivia = null)
+        {
+            var existingTriviaString = existingTrivia?.ToString();
+
+            return SyntaxFactory.Comment(
+                $"// {_message}" +
+                $"{(existingTriviaString?.StartsWith(Environment.NewLine) == true   // i.e. false when there's an #if directive at the beinning of the file
+                    ? ""
+                    : Environment.NewLine)}");
+        }
 
         if (node.HasLeadingTrivia)
         {

--- a/tests/DotnetCombine.Test/TestsInput/Combiner/ComplexScenario/Preprocessor_Beginning.cs
+++ b/tests/DotnetCombine.Test/TestsInput/Combiner/ComplexScenario/Preprocessor_Beginning.cs
@@ -1,0 +1,19 @@
+﻿#if DEBUG
+using System;
+#endif
+
+namespace Endif;
+
+#if DEBUG
+public class A1
+{
+
+}
+#else
+
+public class B1
+{
+
+}
+
+#endif


### PR DESCRIPTION
Fix namespace annotation to prevent `#if` clauses from being inside of the comment.
Fixes #98 